### PR TITLE
Stupid hw 11 solution

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -79,7 +79,7 @@ class APIController {
     }
 
     private val rateLimiter = SlidingWindowRateLimiter(
-        5000,
+        1100,
         Duration.ofSeconds(1)
     )
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -103,8 +103,10 @@ class PaymentExternalSystemAdapterImpl(
     override fun performPaymentAsync(orderId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         val transactionId = UUID.randomUUID()
 
-        paymentScope.launch {
-            executePaymentReactive(paymentId, amount, transactionId)
+        for (i in 1..3) {
+            paymentScope.launch {
+                executePaymentReactive(paymentId, amount, transactionId)
+            }
         }
     }
 

--- a/test-local-run.http
+++ b/test-local-run.http
@@ -5,9 +5,9 @@ Content-Type: application/json
 {
   "serviceName": "{{serviceName}}",
   "token": "{{token}}",
-  "ratePerSecond": 4000,
-  "testCount": 1500000,
-  "processingTimeMillis": 1000
+  "ratePerSecond": 100,
+  "testCount": 20000,
+  "processingTimeMillis": 1500
 }
 
 ### Stop running test to save time and resources

--- a/test-on-prem-run.http
+++ b/test-on-prem-run.http
@@ -6,11 +6,11 @@ Content-Type: application/json
 {
   "serviceName": "{{serviceName}}",
   "token": "{{token}}",
-  "accounts": "acc-13",
-  "branch": "clean_hw_10",
-  "ratePerSecond": 4000,
-  "testCount": 1500000,
-  "processingTimeMillis": 1000
+  "accounts": "acc-22",
+  "branch": "init_hw_11",
+  "ratePerSecond": 100,
+  "testCount": 20000,
+  "processingTimeMillis": 1500
 }
 
 ### Stop running test to save credits


### PR DESCRIPTION
## Results
![telegram-cloud-photo-size-2-5321124636621739354-y](https://github.com/user-attachments/assets/1b3f75b3-be33-45c9-a454-fcf8eaada224)

![telegram-cloud-photo-size-2-5321124636621739355-y](https://github.com/user-attachments/assets/4a3f1b0c-b183-46f4-bafb-7850eb43406d)


## Issues
Видим, что имеем много таймаутов. В среднем сервис отвечает за 1.6s, но deadline установлен в 1.5s
Так же по настройкам аккаунта виден лимит 1100rps, а тест идёт на 100rps.
Поэтому мы можем себе позволить повторять запрос N раз до тех пор, пока тайминг запроса не начнёт попадать в нижний квантиль
Сделал простой перебор и на 3 запросах всё стало удовлетворительно