### PR TITLE
Hw 12 dispatch 5xx

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,37 @@
             <version>${jetty.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-circuitbreaker</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-ratelimiter</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-retry</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-bulkhead</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-cache</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-timelimiter</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
+
 <!--        <dependency>-->
 <!--            <groupId>org.eclipse.jetty</groupId>-->
 <!--            <artifactId>jetty-alpn-server</artifactId>-->

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -79,7 +79,7 @@ class APIController {
     }
 
     private val rateLimiter = SlidingWindowRateLimiter(
-        1100,
+        200,
         Duration.ofSeconds(1)
     )
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -103,10 +103,8 @@ class PaymentExternalSystemAdapterImpl(
     override fun performPaymentAsync(orderId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         val transactionId = UUID.randomUUID()
 
-        for (i in 1..3) {
-            paymentScope.launch {
-                executePaymentReactive(paymentId, amount, transactionId)
-            }
+        paymentScope.launch {
+            executePaymentReactive(paymentId, amount, transactionId)
         }
     }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,15 +2,19 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.micrometer.core.instrument.MeterRegistry
+import io.netty.channel.ChannelOption
 import kotlinx.coroutines.*
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.sync.Semaphore
+import okhttp3.internal.wait
 import org.slf4j.LoggerFactory
-import io.micrometer.core.instrument.MeterRegistry
-import io.netty.channel.ChannelOption
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.WebClientResponseException.TooManyRequests
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.netty.http.HttpProtocol
 import reactor.netty.http.client.HttpClient
@@ -18,14 +22,13 @@ import reactor.netty.resources.ConnectionProvider
 import reactor.netty.resources.LoopResources
 import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.common.utils.SlidingWindowRateLimiter
-import ru.quipy.core.EventSourcingService
-import ru.quipy.payments.api.PaymentAggregate
-import ru.quipy.payments.logic.OrderPayer.Companion
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.*
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import kotlin.time.DurationUnit
 
 
 class PaymentExternalSystemAdapterImpl(
@@ -59,6 +62,16 @@ class PaymentExternalSystemAdapterImpl(
         ).asCoroutineDispatcher()
 
         val paymentScope = CoroutineScope(SupervisorJob() + sharedDispatcher)
+
+        var circuitBreakerConfig: CircuitBreakerConfig = CircuitBreakerConfig.custom()
+            .slidingWindowSize(100)
+            .failureRateThreshold(10F)
+            .waitDurationInOpenState(Duration.ofSeconds(60))
+            .build()
+        var circuitBreakerRegistry: CircuitBreakerRegistry = CircuitBreakerRegistry.of(circuitBreakerConfig)
+        var circuitBreaker: CircuitBreaker = circuitBreakerRegistry
+            .circuitBreaker("cb", circuitBreakerConfig)
+
     }
 
     private val serviceName = properties.serviceName
@@ -109,9 +122,14 @@ class PaymentExternalSystemAdapterImpl(
     }
 
     private suspend fun executePaymentReactive(paymentId: UUID, amount: Int, transactionId: UUID) {
+        while (!circuitBreaker.tryAcquirePermission()) {
+            delay(1000)
+        }
+        val start = now()
         try {
             semaphore.acquire()
             rateLimiter.tickSuspending()
+
             val responseBody = webClient.post()
                 .uri { uriBuilder ->
                     uriBuilder.path("/external/process")
@@ -128,19 +146,22 @@ class PaymentExternalSystemAdapterImpl(
                 .doFinally {
                     semaphore.release()
                 }
+                .timeout(Duration.ofSeconds(1))
                 .awaitSingle()
+            val end = now()
 
             successCounter.increment()
-        } catch (e: TooManyRequests) {
-            logger.error("[$accountName] Payment failed for txId: $transactionId, with 429, retrying")
-            executePaymentReactive(paymentId, amount, transactionId)
+            circuitBreaker.onSuccess(end - start, TimeUnit.MILLISECONDS)
         } catch (e: Exception) {
             logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
 
             when (e) {
+                is WebClientResponseException.TooManyRequests -> executePaymentReactive(paymentId, amount, transactionId)
                 is TimeoutException, is SocketTimeoutException -> timeoutCounter.increment()
                 else -> errorCounter.increment()
             }
+            val end = now()
+            circuitBreaker.onError(end - start, TimeUnit.MILLISECONDS, e)
         }
     }
 

--- a/test-local-run.http
+++ b/test-local-run.http
@@ -6,8 +6,8 @@ Content-Type: application/json
   "serviceName": "{{serviceName}}",
   "token": "{{token}}",
   "ratePerSecond": 100,
-  "testCount": 20000,
-  "processingTimeMillis": 1500
+  "testCount": 50000,
+  "processingTimeMillis": 10000000
 }
 
 ### Stop running test to save time and resources

--- a/test-on-prem-run.http
+++ b/test-on-prem-run.http
@@ -7,7 +7,7 @@ Content-Type: application/json
   "serviceName": "{{serviceName}}",
   "token": "{{token}}",
   "accounts": "acc-19",
-  "branch": "init_hw_12",
+  "branch": "hw-12-dispatch-5xx",
   "ratePerSecond": 100,
   "testCount": 50000,
   "processingTimeMillis": 10000000

--- a/test-on-prem-run.http
+++ b/test-on-prem-run.http
@@ -6,11 +6,11 @@ Content-Type: application/json
 {
   "serviceName": "{{serviceName}}",
   "token": "{{token}}",
-  "accounts": "acc-22",
-  "branch": "init_hw_11",
+  "accounts": "acc-19",
+  "branch": "init_hw_12",
   "ratePerSecond": 100,
-  "testCount": 20000,
-  "processingTimeMillis": 1500
+  "testCount": 50000,
+  "processingTimeMillis": 10000000
 }
 
 ### Stop running test to save credits


### PR DESCRIPTION
## Before
![telegram-cloud-photo-size-2-5321124636621739370-y](https://github.com/user-attachments/assets/c36420a0-a8bf-4f91-ba3d-46cefa4bc5ef)

## After
![telegram-cloud-photo-size-2-5321124636621739397-y](https://github.com/user-attachments/assets/e38d2ab0-97c0-455c-8986-e474e0084af4)

## Issues
Видно, что периодически сервер начинает отдавать 5xx
![telegram-cloud-photo-size-2-5321124636621739373-y](https://github.com/user-attachments/assets/eb2b7247-d9a9-4f53-81a7-a522ff220544)

Таймаут у аккаунта большой, поэтому первое решение было добавить эти ошибки в `retriable` и просто повтарять их со sleep-ом (как 429)
Тогда мы стали "догонять" все запросы попавшие на даунтайм, но почему-то система считает это за expenses (видимо из-за большого числа запросов)

Следуюшая итерация была через добавление CircuitBreaker. Решение также не помогло.
Руткоз был в том, что 5хх вылетают с высоким таймингом. И за эти 30 секунд очень много запросов также получают 5xx

В финальное решение был добавлен timeout 1 секунда на запрос и в случае пробития этого тайминга мы отдаём circuitBreaker.onError

Таким образом CircuitBreaker обрабатывает как ошибки, так и зависания.